### PR TITLE
Use portable PRIu64 macro instead of %lu for uint64_t

### DIFF
--- a/examples/ulog_info.cpp
+++ b/examples/ulog_info.cpp
@@ -109,8 +109,8 @@ int main(int argc, char** argv)
     if (logging.hasTag()) {
       tag_str = std::to_string(logging.tag()) + " ";
     }
-    printf(" %s<%s> %" PRIu64 " %s\n", tag_str.c_str(), logging.logLevelStr().c_str(), logging.timestamp(),
-           logging.message().c_str());
+    printf(" %s<%s> %" PRIu64 " %s\n", tag_str.c_str(), logging.logLevelStr().c_str(),
+           logging.timestamp(), logging.message().c_str());
   }
 
   // Params (init, after, defaults)

--- a/examples/ulog_info.cpp
+++ b/examples/ulog_info.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <algorithm>
+#include <cinttypes>
 #include <fstream>
 #include <iostream>
 #include <numeric>
@@ -108,7 +109,7 @@ int main(int argc, char** argv)
     if (logging.hasTag()) {
       tag_str = std::to_string(logging.tag()) + " ";
     }
-    printf(" %s<%s> %lu %s\n", tag_str.c_str(), logging.logLevelStr().c_str(), logging.timestamp(),
+    printf(" %s<%s> %" PRIu64 " %s\n", tag_str.c_str(), logging.logLevelStr().c_str(), logging.timestamp(),
            logging.message().c_str());
   }
 


### PR DESCRIPTION
When printing uint64_t variable, PRIu64 should be used as it's a portable and standard way.