### PR TITLE
Add Version Check to GCC Warning

### DIFF
--- a/ulog_cpp/messages.hpp
+++ b/ulog_cpp/messages.hpp
@@ -434,14 +434,14 @@ class Value {
       throw AccessException("Unexpected data type size");
     }
     // GCC 14.2 raises an error here when building with -fsanitize=address
-#ifdef __GNUC__
+#if defined(__GNUC__) && (__GNUC__ >= 14)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
     std::copy(backing_start + total_offset, backing_start + total_offset + sizeof(v),
               reinterpret_cast<uint8_t*>(&v));
-#ifdef __GNUC__
+#if defined(__GNUC__) && (__GNUC__ >= 14)
 #pragma GCC diagnostic pop
 #endif
     return v;


### PR DESCRIPTION
Or alternatively:
```
  template <typename T>
  static T deserialize(const std::vector<uint8_t>::const_iterator& backing_start,
                       const std::vector<uint8_t>::const_iterator& backing_end,
                       int offset,
                       int array_offset)
  {
    T v;
    const std::ptrdiff_t total_offset =
        static_cast<std::ptrdiff_t>(offset) +
        (static_cast<std::ptrdiff_t>(array_offset) * sizeof(T));

    if (backing_start > backing_end ||
        backing_end - backing_start < sizeof(v) + total_offset) {
      throw AccessException("Unexpected data type size");
    }

    const uint8_t* src = &*(backing_start + total_offset);
    std::memcpy(&v, src, sizeof(v));

    return v;
  }
  ```