### PR TITLE
cmake: several improvements for installing/subproject use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,42 +1,54 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-project(ulog_cpp LANGUAGES CXX)
+project(ulog_cpp
+    VERSION 1.0.0
+    LANGUAGES CXX
+    DESCRIPTION "C++ library for handling ULog files"
+)
 
-# Determine if ulog_cpp is built as a subproject (using add_subdirectory) or if it is the main project.
-set(MAIN_PROJECT OFF)
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    set(MAIN_PROJECT ON)
-endif()
+include(CMakeDependentOption)
+
+cmake_dependent_option(ULOG_CPP_INSTALL "Install the ulog_cpp folder to include/ during install process"
+		ON "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
+cmake_dependent_option(ULOG_CPP_BUILD_TESTS "Build ulog_cpp tests" ON
+		"CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(ulog_cpp)
 
-if(MAIN_PROJECT)
+# Only create and install the config files if this is the main project
+if(ULOG_CPP_INSTALL)
+	include(GNUInstallDirs)
 	include(CMakePackageConfigHelpers)
 
-	write_basic_package_version_file(
-		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-		VERSION 1.0.0
-		COMPATIBILITY AnyNewerVersion
-	)
+    # Create a config file that includes the export
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
 
-	configure_package_config_file(
-		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
-		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-		INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
-	)
+    # Create a version file
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-	install(FILES
-		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-		DESTINATION lib/cmake/${PROJECT_NAME}
-	)
+    # Install the config files
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
 
 
 	add_compile_options(
@@ -69,7 +81,10 @@ if(MAIN_PROJECT)
 	include(clang_format)
 
 	add_subdirectory(examples)
-	add_subdirectory(test)
+
+	if (ULOG_CPP_BUILD_TESTS)
+		add_subdirectory(test)
+	endif()
 
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT doctest_FOUND)
 	FetchContent_Declare(
 		doctest
 		GIT_REPOSITORY "https://github.com/doctest/doctest.git"
-		GIT_TAG "v2.4.11"
+		GIT_TAG "v2.4.12"
 		${SYSTEM_ARG}
 	)
 	FetchContent_MakeAvailable(doctest)

--- a/ulog_cpp/CMakeLists.txt
+++ b/ulog_cpp/CMakeLists.txt
@@ -10,24 +10,48 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-      $<INSTALL_INTERFACE:include/ulog_cpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}Targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION include/ulog_cpp
-    FILES_MATCHING PATTERN "*.hpp"
-)
+if(ULOG_CPP_INSTALL)
+    # Set the target properties
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        PUBLIC_HEADER ""
+    )
 
-install(EXPORT ${PROJECT_NAME}Targets
-    FILE ${PROJECT_NAME}Targets.cmake
-    NAMESPACE ${PROJECT_NAME}::
-    DESTINATION lib/cmake/${PROJECT_NAME}
-)
+    # Install the library
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    # Install headers preserving directory structure
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+        FILES_MATCHING
+            PATTERN "*.hpp"
+            PATTERN "*.h"
+    )
+
+    # Generate and install the export
+    include(CMakePackageConfigHelpers)
+    install(EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+
+    # Export the target for the build tree
+    export(TARGETS ${PROJECT_NAME}
+        NAMESPACE ${PROJECT_NAME}::
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
+    )
+endif()


### PR DESCRIPTION
- add separate options ULOG_CPP_INSTALL and ULOG_CPP_BUILD_TESTS
- use cmake install path variables
- do not install headers and cmake files when used as subproject
  This is important when e.g. building a debian package using this via
  submodule or FetchContent.

doctest: update to version 2.4.12